### PR TITLE
Use Redis settings passed in from the settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Install the npm package by running `npm install node-red-contrib-redis-storage` 
 
 Then, add the following configuration option to your `settings.js` file:
 ```javascript
+redis: {
+  host: your.redis.host,
+  pass: your.redis.password,
+  port: your.redis.port
+},
 storageModule: require("node-red-contrib-redis-storage")
 ```
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,8 @@ var util = require('util'),
     when = require('when')
 
 // Redis setup
-var redis = require("redis"),
-    redisURL = process.env.REDIS_URL,
-    client = redis.createClient(redisURL);
+var redis = require("redis");
+var client;
 
 // Private variables and functions
 var settings;
@@ -50,6 +49,9 @@ var redisStorage = {
     settings = _settings;
     log.info("initialized with settings:");
     log.info(util.inspect(settings));
+    // init redis client connection
+    client = redis.createClient(settings.redis);
+
     return when.promise(function(resolve,reject) {
       resolve();
     });


### PR DESCRIPTION
Rather than using the REDIS_URL environment variable, allow more cutomization via a `settings.redis`  object.